### PR TITLE
Changing object-literal-key-quotes rules

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -94,7 +94,7 @@
 		"no-var-keyword": true,
 		"no-var-requires": true,
 		"object-literal-key-quotes": {
-			"options": ["consistent-as-needed"]
+			"options": ["as-needed"]
 		},
 		"object-literal-shorthand": true,
 		"object-literal-sort-keys": true,


### PR DESCRIPTION
I don't think we should force every property to be quoted if one or two need it.