### PR TITLE
Disable object-literal-sort-keys

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -97,7 +97,7 @@
 			"options": ["consistent-as-needed"]
 		},
 		"object-literal-shorthand": true,
-		"object-literal-sort-keys": true,
+		"object-literal-sort-keys": false,
 		"one-line": {
 			"options": [
 				"check-catch",
@@ -229,7 +229,7 @@
 		"no-unused-expression": true,
 		// disable this rule as it is very heavy performance-wise and not that useful
 		"no-use-before-declare": false,
-		"object-literal-sort-keys": true,
+		"object-literal-sort-keys": false,
 		"one-line": {
 			"options": [
 				"check-catch",


### PR DESCRIPTION
Whilst this rule sounds good in theory it is not so good in practice.

For example with a redux action I want the type property first as it is the most pertinent information:

```
{
    type: actions.LOAD_SUCCESS,
    payload: payload
}
```

I also personally prefer to have direct ancestor information above child objects.

```
{
    bar: "bar",
    foo: "foo",
    buzz: {
        ...
    }
}
```