### PR TITLE
Changing array type from generic to []

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -9,7 +9,7 @@
 			]
 		},
 		"array-type": {
-			"options": ["generic"]
+			"options": ["array"]
 		},
 		"arrow-parens": false,
 		"arrow-return-shorthand": true,


### PR DESCRIPTION
I wanted to start a discussion on this.  
My preference for array types is `T[]` as opposed to the generic form `Array<T>`

It is more concise, less typing (2 chars as opposed to 7) and puts the more important information up front (what is this an array of).

But this is quite a significant change so I would be interested to see what the consensus of the company is.