### PR TITLE
add switch default rule

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -138,6 +138,7 @@
 				"named": "never"
 			}
 		},
+		"switch-default": true,
 		"trailing-comma": false,
 		"triple-equals": {
 			"options": ["allow-null-check"]


### PR DESCRIPTION
This rule enforces using a default on a switch statement

```typescript
// good
switch (something) {
   case "a value":
      doThis();
      break;
   default:
      doDefault();
      break;
}

// bad
switch (something) {
   case "a value":
      doThis();
      break;
}

doDefault();
```